### PR TITLE
Add initial Expo mobile frontend skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+.expo
+.DS_Store
+.env

--- a/App.tsx
+++ b/App.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { SafeAreaView, TextInput, Button, View, Text, StyleSheet, FlatList } from 'react-native';
+
+export default function App() {
+  const [entry, setEntry] = useState('');
+  const [items, setItems] = useState<string[]>([]);
+
+  const addEntry = () => {
+    if (entry.trim().length === 0) return;
+    setItems([...items, entry.trim()]);
+    setEntry('');
+  };
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.inputContainer}>
+        <TextInput
+          style={styles.input}
+          placeholder="Örneğin: Sabah 2 haşlanmış yumurta"
+          value={entry}
+          onChangeText={setEntry}
+        />
+        <Button title="Ekle" onPress={addEntry} />
+      </View>
+      <FlatList
+        data={items}
+        keyExtractor={(item, index) => index.toString()}
+        renderItem={({ item }) => <Text style={styles.item}>{item}</Text>}
+      />
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    paddingTop: 50,
+    paddingHorizontal: 20,
+  },
+  inputContainer: {
+    flexDirection: 'row',
+    marginBottom: 20,
+  },
+  input: {
+    flex: 1,
+    borderWidth: 1,
+    borderColor: '#ccc',
+    marginRight: 10,
+    padding: 10,
+    borderRadius: 4,
+  },
+  item: {
+    padding: 10,
+    fontSize: 16,
+    borderBottomWidth: 1,
+    borderColor: '#eee',
+  },
+});

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# kalorici
+# Kalorici Mobile App
+
+This project is a basic scaffold for a React Native mobile application using **Expo**. It will let users enter meal descriptions in natural language. The backend and NLP integration are not implemented yet.
+
+## Getting Started
+
+1. Install dependencies (requires Node.js):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm start
+   ```
+   You can then run the app on a simulator or a connected device using the Expo CLI instructions.
+
+## Project Structure
+
+- `App.tsx` – main application file containing a simple text input and list of entered items.
+- `app.json` – Expo configuration.
+- `package.json` – project dependencies and scripts.
+
+## Next Steps
+
+- Implement NLP parsing of entries (OpenAI GPT or other model).
+- Connect to a nutrition database to fetch calorie and macro information.
+- Store user data in a backend (e.g., Supabase).

--- a/app.json
+++ b/app.json
@@ -1,0 +1,22 @@
+{
+  "expo": {
+    "name": "kalorici",
+    "slug": "kalorici",
+    "version": "1.0.0",
+    "sdkVersion": "49.0.0",
+    "platforms": ["ios", "android", "web"],
+    "orientation": "portrait",
+    "icon": "./assets/icon.png",
+    "splash": {
+      "image": "./assets/splash.png",
+      "resizeMode": "contain",
+      "backgroundColor": "#ffffff"
+    },
+    "updates": {
+      "fallbackToCacheTimeout": 0
+    },
+    "assetBundlePatterns": [
+      "**/*"
+    ]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "kalorici",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "expo": "^49.0.0",
+    "react": "18.2.0",
+    "react-native": "0.72.4"
+  }
+}


### PR DESCRIPTION
## Summary
- initialize npm project and Expo config
- add basic React Native App.tsx
- document setup steps in README
- ignore node_modules and environment files

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68402c18ea008333bc6cd748835e57b2